### PR TITLE
docs: fix minor typo in context menu doc

### DIFF
--- a/apps/showcase/doc/datatable/ContextMenuDoc.vue
+++ b/apps/showcase/doc/datatable/ContextMenuDoc.vue
@@ -1,7 +1,7 @@
 <template>
     <DocSectionText v-bind="$attrs">
         <p>
-            DataTable has exclusive integration with ContextMenu using the <i>contextMenu</i> event to open a menu on right click alont with <i>contextMenuSelection</i> property and <i>row-contextmenu</i> event to control the selection via the menu.
+            DataTable has exclusive integration with ContextMenu using the <i>contextMenu</i> event to open a menu on right click along with <i>contextMenuSelection</i> property and <i>row-contextmenu</i> event to control the selection via the menu.
         </p>
     </DocSectionText>
     <DeferredDemo @load="loadDemoData">


### PR DESCRIPTION
### Defect Fixes

Very minor typo in the documentation. diff is self-explanatory.
